### PR TITLE
Remove cast to np.mat to remove pending depreciation warning.

### DIFF
--- a/hlsvdpropy/hlsvd.py
+++ b/hlsvdpropy/hlsvd.py
@@ -149,7 +149,7 @@ def hlsvdpro(data, nsv_sought, m=None, sparse=False):
 
     k = min(k,len(s))               # number of singular values found
         
-    uk = np.mat(u[:, :k])           # trucated U matrix of rank K
+    uk = u[:, :k]           # trucated U matrix of rank K
     ub = uk[:-1]                    # Uk with bottom row removed
     ut = uk[1:]                     # Uk with top row removed
 


### PR DESCRIPTION
In python 3.8+ I get a
```
PendingDeprecationWarning: the matrix subclass is not the recommended way to represent matrices or deal with linear algebra (see https://docs.scipy.org/doc/numpy/user/numpy-for-matlab-users.html). Please adjust your code to use regular ndarray.

../../../opt/miniconda3/envs/fsl_mrs/lib/python3.8/site-packages/numpy/matrixlib/defmatrix.py:116: PendingDeprecationWarning
```
The traceback indicates this occurs on line 153 of the hlsvd code in a call to `np.mat`.

```
fsl_mrs/utils/preproc/remove.py:124: in _hlsvd
    r = hlsvdpropy.hlsvdpro(FID, numSingularValues, m=m, sparse=sparse_algo)
../../../opt/miniconda3/envs/fsl_mrs/lib/python3.8/site-packages/hlsvdpropy/hlsvd.py:153: in hlsvdpro
    uk = np.mat(u[:, :k])           # trucated U matrix of rank K
../../../opt/miniconda3/envs/fsl_mrs/lib/python3.8/site-packages/numpy/matrixlib/defmatrix.py:69: in asmatrix
    return matrix(data, dtype=dtype, copy=False)
```
Removing the call to np.mat removes the warning and results in no difference when performing the packaged test. Both return
```
0 - RMSE = 45.84, normalized RMSE = 0.77%
1 - RMSE = 45.84, normalized RMSE = 0.77%
```
for python 3.6 and 3.8 with this change.