### PR TITLE
BF: Remove deprecated pkg_resources dependency

### DIFF
--- a/hlsvdpropy/__init__.py
+++ b/hlsvdpropy/__init__.py
@@ -16,11 +16,9 @@ Dependencies:
 """      
 
 from __future__ import division
-
-# 3rd party imports
-import pkg_resources
+from importlib.metadata import version
 
 # This removes a useless layer of naming indirection.
 from hlsvdpropy.hlsvd import *
 
-__version__ = pkg_resources.get_distribution('hlsvdpropy').version
+__version__ = version('hlsvdpropy')


### PR DESCRIPTION
As of python 3.9 the use of `pkg_resources` results in the following warning

```
../../../opt/conda/envs/fsl_mrs/lib/python3.9/site-packages/hlsvdpropy/__init__.py:21
  /opt/conda/envs/fsl_mrs/lib/python3.9/site-packages/hlsvdpropy/__init__.py:21: DeprecationWarning:
  
  pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
```

This PR replaces the `pkg_resources` dependency for the [recommended](https://setuptools.pypa.io/en/latest/pkg_resources.html) `importlib` method.