### PR TITLE
BF: Remove residual pkg_resources dependency

### DIFF
--- a/hlsvdpropy/__init__.py
+++ b/hlsvdpropy/__init__.py
@@ -15,23 +15,14 @@ Dependencies:
     
 """      
 try:
-    import importlib.metadata
+    from importlib.metadata import version
     version_method = 'importlib'
-except:
+    __version__ = version('hlsvdpropy')
+except ImportError:
     # 3rd party imports
     import pkg_resources
     version_method = 'pkg_resources'
-
-from importlib.metadata import version
-
-# 3rd party imports
-import pkg_resources
+    __version__ = pkg_resources.get_distribution('hlsvdpropy').version
 
 # This removes a useless layer of naming indirection.
 from hlsvdpropy.hlsvd import *
-
-if version_method == 'importlib':
-    __version__ = version('hlsvdpropy')
-else:
-    __version__ = pkg_resources.get_distribution('hlsvdpropy').version
-


### PR DESCRIPTION
Hi Brian,

Your implementation of my proposed fix left a residual pkg_resources dependency on L28 of` __init__.py`

This should remove it and solve the upcoming problems in python 3.12 (where `pkg_resources` is finally removed).